### PR TITLE
Add login authentication function

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type StorageConfig struct {
 	Bucket   string `json:"bucket"`
 }
 
+// Config 应用配置结构体
 type Config struct {
 	Port                string         `json:"port"`
 	Debug               bool           `json:"debug"`
@@ -31,7 +32,15 @@ type Config struct {
 	// max log file size, unit is mb
 	MaxLogFileSizeOfMB int64 `json:"maxLogFileSizeOfMB"`
 	// max log file size, unit is day
-	MaxLogLifeTimeOfHour int64 `json:"maxLogLifeTimeOfHour"`
+	MaxLogLifeTimeOfHour int64       `json:"maxLogLifeTimeOfHour"`
+	AuthConfig           *AuthConfig `json:"authConfig"`
+}
+
+// AuthConfig 认证配置结构体
+type AuthConfig struct {
+	Password        string `json:"password"`        // 认证密码
+	JwtSecret       string `json:"jwtSecret"`       // JWT密钥
+	TokenExpiration int    `json:"tokenExpiration"` // 令牌过期时间(小时)
 }
 
 func (c *Config) IsRemoteStorage() bool {

--- a/config/defaultConfig.json
+++ b/config/defaultConfig.json
@@ -1,3 +1,8 @@
 {
-	"port": "6752"
+	"port": "6752",
+	"authConfig": {
+		"password": "",
+		"jwtSecret": "",
+		"tokenExpiration": 24
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GM
 github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbuBVKCudVG457BR2GZFIz3uw3hQ=
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=

--- a/serve/common/api.go
+++ b/serve/common/api.go
@@ -28,6 +28,24 @@ func NewErrorResponse(err error) *Response {
 	}
 }
 
+// NewErrorResponseWithCode 创建包含自定义错误码的错误响应
+func NewErrorResponseWithCode(message string, code string) *Response {
+	resp := &Response{
+		Code:    code,
+		Success: false,
+		Message: message,
+	}
+
+	// 特殊处理：密码未设置的情况
+	if code == "PASSWORD_REQUIRED" {
+		resp.Data = map[string]interface{}{
+			"needPasswordSetup": true,
+		}
+	}
+
+	return resp
+}
+
 func NewSuccessResponse(data interface{}) *Response {
 	return &Response{
 		Code:    "success",

--- a/serve/middleware/auth.go
+++ b/serve/middleware/auth.go
@@ -1,0 +1,110 @@
+package middleware
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/HuolalaTech/page-spy-api/config"
+	"github.com/HuolalaTech/page-spy-api/serve/common"
+	"github.com/labstack/echo/v4"
+)
+
+// configMutex 用于保护配置文件的并发写入
+var configMutex = &sync.Mutex{}
+
+// SaveConfigToFile 将配置保存到文件
+func SaveConfigToFile(cfg *config.Config) error {
+	configMutex.Lock()
+	defer configMutex.Unlock()
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(config.ConfigFileName, data, 0644)
+}
+
+// Auth 中间件用于验证请求的认证信息
+func Auth(cfg *config.Config) echo.MiddlewareFunc {
+	// 初始化JWT密钥
+	InitJWTSecret(cfg)
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// 获取Authorization头
+			authHeader := c.Request().Header.Get("Authorization")
+			if authHeader == "" {
+				return c.JSON(http.StatusUnauthorized, common.NewErrorResponseWithCode("未提供认证令牌", "MISSING_TOKEN"))
+			}
+
+			// Bearer Token格式验证
+			parts := strings.Split(authHeader, " ")
+			if len(parts) != 2 || parts[0] != "Bearer" {
+				return c.JSON(http.StatusUnauthorized, common.NewErrorResponseWithCode("认证令牌格式无效", "INVALID_TOKEN_FORMAT"))
+			}
+
+			token := parts[1]
+
+			// 解析和验证JWT令牌
+			claims, err := ParseToken(token)
+			if err != nil {
+				return c.JSON(http.StatusUnauthorized, common.NewErrorResponseWithCode("认证令牌已过期或无效", "EXPIRED_OR_INVALID_TOKEN"))
+			}
+
+			// 将JWT声明存储在上下文中，以便后续使用
+			c.Set("jwtClaims", claims)
+
+			return next(c)
+		}
+	}
+}
+
+// IsPasswordSet 检查是否已设置密码
+func IsPasswordSet(cfg *config.Config) bool {
+	// 检查环境变量中是否设置了密码
+	if envPassword := os.Getenv("AUTH_PASSWORD"); envPassword != "" {
+		return true
+	}
+
+	// 检查配置文件中是否设置了密码
+	return cfg.AuthConfig != nil && cfg.AuthConfig.Password != ""
+}
+
+// VerifyPassword 验证密码是否正确
+func VerifyPassword(cfg *config.Config, password string) bool {
+	// 优先检查环境变量中的密码
+	if envPassword := os.Getenv("AUTH_PASSWORD"); envPassword != "" {
+		return password == envPassword
+	}
+
+	// 其次检查配置文件中的密码
+	if cfg.AuthConfig != nil {
+		return password == cfg.AuthConfig.Password
+	}
+
+	return false
+}
+
+// SetPassword 设置密码到配置文件
+func SetPassword(cfg *config.Config, password string) error {
+	// 如果环境变量中已设置密码，则不允许通过接口修改
+	if envPassword := os.Getenv("AUTH_PASSWORD"); envPassword != "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "系统使用环境变量中的密码，无法通过接口设置")
+	}
+
+	// 更新配置中的密码
+	if cfg.AuthConfig == nil {
+		cfg.AuthConfig = &config.AuthConfig{
+			TokenExpiration: 24, // 默认24小时
+		}
+	}
+	cfg.AuthConfig.Password = password
+
+	// 保存配置到文件
+	return SaveConfigToFile(cfg)
+}

--- a/serve/middleware/jwt.go
+++ b/serve/middleware/jwt.go
@@ -1,0 +1,137 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/HuolalaTech/page-spy-api/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// 用于签名JWT的密钥
+var jwtSecret []byte
+
+// Claims JWT声明结构
+type Claims struct {
+	jwt.RegisteredClaims
+}
+
+// InitJWTSecret 初始化JWT密钥
+func InitJWTSecret(cfg *config.Config) {
+	// 优先使用环境变量中的密钥
+	envSecret := os.Getenv("JWT_SECRET")
+	if envSecret != "" {
+		jwtSecret = []byte(envSecret)
+		return
+	}
+
+	// 其次使用配置文件中的密钥
+	if cfg.AuthConfig != nil && cfg.AuthConfig.JwtSecret != "" {
+		jwtSecret = []byte(cfg.AuthConfig.JwtSecret)
+		return
+	}
+
+	// 如果配置文件中没有密钥，则生成新的密钥并保存
+	newSecret := generateRandomKey(32)
+	jwtSecret = newSecret
+
+	// 更新配置
+	if cfg.AuthConfig == nil {
+		cfg.AuthConfig = &config.AuthConfig{
+			TokenExpiration: 24, // 默认24小时
+		}
+	}
+	cfg.AuthConfig.JwtSecret = base64.StdEncoding.EncodeToString(newSecret)
+
+	// 保存新的配置
+	SaveConfigToFile(cfg)
+}
+
+// 生成随机密钥
+func generateRandomKey(length int) []byte {
+	key := make([]byte, length)
+	_, err := rand.Read(key)
+	if err != nil {
+		// 如果随机生成失败，使用时间戳作为备选方案
+		now := time.Now().UnixNano()
+		for i := 0; i < length; i++ {
+			key[i] = byte((now >> (i % 8)) & 0xff)
+		}
+	}
+	return key
+}
+
+// GetJWTExpirationHours 获取JWT过期时间
+func GetJWTExpirationHours(cfg *config.Config) int {
+	// 从配置中获取过期时间
+	if cfg.AuthConfig != nil && cfg.AuthConfig.TokenExpiration > 0 {
+		return cfg.AuthConfig.TokenExpiration
+	}
+
+	// 默认24小时
+	return 24
+}
+
+// GenerateToken 生成JWT令牌
+func GenerateToken(cfg *config.Config) (string, int, error) {
+	// 确保JWT密钥已初始化
+	if len(jwtSecret) == 0 {
+		InitJWTSecret(cfg)
+	}
+
+	// 确定过期时间
+	expirationHours := GetJWTExpirationHours(cfg)
+	expirationTime := time.Now().Add(time.Hour * time.Duration(expirationHours))
+
+	// 创建声明
+	claims := &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expirationTime),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now()),
+			Issuer:    "page-spy",
+		},
+	}
+
+	// 创建令牌
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	// 签名令牌
+	tokenString, err := token.SignedString(jwtSecret)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return tokenString, expirationHours, nil
+}
+
+// ParseToken 解析和验证JWT令牌
+func ParseToken(tokenString string) (*Claims, error) {
+	// 确保JWT密钥已初始化
+	if len(jwtSecret) == 0 {
+		return nil, fmt.Errorf("JWT密钥未初始化")
+	}
+
+	// 解析JWT令牌
+	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
+		// 验证签名方法
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return jwtSecret, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// 提取声明
+	if claims, ok := token.Claims.(*Claims); ok && token.Valid {
+		return claims, nil
+	}
+
+	return nil, fmt.Errorf("invalid token")
+}

--- a/serve/route/route.go
+++ b/serve/route/route.go
@@ -100,27 +100,127 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 	e.HidePort = true
 	e.HideBanner = true
 	route := e.Group("/api/v1")
-	route.GET("/room/list", func(c echo.Context) error {
-		socket.ListRooms(c.Response(), c.Request())
-		return nil
+
+	// 公共路由 - 无需认证
+	publicRoute := route.Group("")
+
+	// 认证相关API
+	publicRoute.POST("/auth/verify", func(c echo.Context) error {
+		type PasswordRequest struct {
+			Password string `json:"password"`
+		}
+
+		// 解析请求体中的密码
+		var passwordReq PasswordRequest
+		if err := c.Bind(&passwordReq); err != nil {
+			return c.JSON(http.StatusBadRequest, common.NewErrorResponseWithCode("无效的请求格式", "INVALID_REQUEST"))
+		}
+
+		// 检查是否设置了密码
+		if !selfMiddleware.IsPasswordSet(config) {
+			return c.JSON(http.StatusOK, common.NewErrorResponseWithCode("系统未设置密码，请先设置密码", "PASSWORD_REQUIRED"))
+		}
+
+		// 验证密码
+		if !selfMiddleware.VerifyPassword(config, passwordReq.Password) {
+			return c.JSON(http.StatusOK, common.NewErrorResponseWithCode("密码错误", "INVALID_PASSWORD"))
+		}
+
+		// 生成JWT令牌
+		token, expirationHours, err := selfMiddleware.GenerateToken(config)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, common.NewErrorResponseWithCode("生成令牌失败", "TOKEN_GENERATION_FAILED"))
+		}
+
+		return c.JSON(http.StatusOK, common.NewSuccessResponse(map[string]interface{}{
+			"success":   true,
+			"message":   "认证成功",
+			"token":     token,
+			"expiresIn": expirationHours * 3600, // 过期时间，单位秒
+		}))
 	})
 
-	route.POST("/room/create", func(c echo.Context) error {
+	// 设置密码接口
+	publicRoute.POST("/auth/set-password", func(c echo.Context) error {
+		type PasswordRequest struct {
+			Password string `json:"password"`
+		}
+
+		// 解析请求体中的密码
+		var passwordReq PasswordRequest
+		if err := c.Bind(&passwordReq); err != nil {
+			return c.JSON(http.StatusBadRequest, common.NewErrorResponseWithCode("无效的请求格式", "INVALID_REQUEST"))
+		}
+
+		// 检查是否已经设置了密码
+		if selfMiddleware.IsPasswordSet(config) {
+			return c.JSON(http.StatusOK, common.NewErrorResponseWithCode("密码已设置，不能重复设置", "PASSWORD_ALREADY_SET"))
+		}
+
+		// 密码验证逻辑
+		if passwordReq.Password == "" {
+			return c.JSON(http.StatusOK, common.NewErrorResponseWithCode("密码不能为空", "INVALID_PASSWORD"))
+		}
+
+		// 设置密码
+		err := selfMiddleware.SetPassword(config, passwordReq.Password)
+		if err != nil {
+			// 如果是因为环境变量设置了密码导致的错误
+			if httpErr, ok := err.(*echo.HTTPError); ok {
+				return c.JSON(http.StatusOK, common.NewErrorResponseWithCode(httpErr.Message.(string), "ENV_PASSWORD_SET"))
+			}
+			return c.JSON(http.StatusInternalServerError, common.NewErrorResponseWithCode("设置密码失败", "PASSWORD_SET_FAILED"))
+		}
+
+		// 生成JWT令牌
+		token, expirationHours, err := selfMiddleware.GenerateToken(config)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, common.NewErrorResponseWithCode("生成令牌失败", "TOKEN_GENERATION_FAILED"))
+		}
+
+		return c.JSON(http.StatusOK, common.NewSuccessResponse(map[string]interface{}{
+			"success":            true,
+			"message":            "密码设置成功",
+			"token":              token,
+			"passwordConfigured": true,
+			"expiresIn":          expirationHours * 3600, // 过期时间，单位秒
+		}))
+	})
+
+	// 密码状态检查接口
+	publicRoute.GET("/auth/status", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, common.NewSuccessResponse(map[string]interface{}{
+			"passwordConfigured": selfMiddleware.IsPasswordSet(config),
+		}))
+	})
+
+	// 无需认证的公共接口
+	publicRoute.POST("/room/create", func(c echo.Context) error {
 		socket.CreateRoom(c.Response(), c.Request())
 		return nil
 	})
 
-	route.GET("/ws/room/join", func(c echo.Context) error {
+	publicRoute.GET("/ws/room/join", func(c echo.Context) error {
 		socket.JoinRoom(c.Response(), c.Request())
 		return nil
 	})
 
-	route.GET("/room/check", func(c echo.Context) error {
+	publicRoute.GET("/room/check", func(c echo.Context) error {
 		socket.CheckRoomSecret(c.Response(), c.Request())
 		return nil
 	})
 
-	route.GET("/log/download", func(c echo.Context) error {
+	// 受保护的路由组 - 需要认证
+	protectedRoute := route.Group("")
+	protectedRoute.Use(selfMiddleware.Auth(config))
+
+	// 需要认证的API
+	protectedRoute.GET("/room/list", func(c echo.Context) error {
+		socket.ListRooms(c.Response(), c.Request())
+		return nil
+	})
+
+	protectedRoute.GET("/log/download", func(c echo.Context) error {
 		fileId := c.QueryParam("fileId")
 		machine, err := core.GetMachineIdByFileName(fileId)
 		if err != nil {
@@ -147,7 +247,7 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		return nil
 	})
 
-	route.GET("/logGroup/list", func(c echo.Context) error {
+	protectedRoute.GET("/logGroup/list", func(c echo.Context) error {
 		query, err := getQueryList(c)
 		if err != nil {
 			return err
@@ -161,7 +261,7 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		return c.JSON(200, common.NewSuccessResponse(logGroups))
 	})
 
-	route.GET("/logGroup/files", func(c echo.Context) error {
+	protectedRoute.GET("/logGroup/files", func(c echo.Context) error {
 		groupId := c.QueryParam("groupId")
 		if groupId == "" {
 			return fmt.Errorf("groupId is required")
@@ -175,7 +275,7 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		return c.JSON(200, common.NewSuccessResponse(logFiles))
 	})
 
-	route.GET("/log/list", func(c echo.Context) error {
+	protectedRoute.GET("/log/list", func(c echo.Context) error {
 		query, err := getQueryList(c)
 		if err != nil {
 			return err
@@ -189,7 +289,7 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		return c.JSON(200, common.NewSuccessResponse(logs))
 	})
 
-	route.DELETE("/log/delete", func(c echo.Context) error {
+	protectedRoute.DELETE("/log/delete", func(c echo.Context) error {
 		if config.NotAllowedDeleteLog {
 			return fmt.Errorf("not allowed delete log")
 		}
@@ -213,7 +313,7 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		return c.JSON(200, common.NewSuccessResponse(true))
 	})
 
-	route.DELETE("/logGroup/delete", func(c echo.Context) error {
+	protectedRoute.DELETE("/logGroup/delete", func(c echo.Context) error {
 		if config.NotAllowedDeleteLog {
 			return fmt.Errorf("not allowed delete log")
 		}
@@ -230,7 +330,8 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		return c.JSON(200, common.NewSuccessResponse(true))
 	})
 
-	route.POST("/logGroup/upload", func(c echo.Context) error {
+	// 以下是需要公开的上传接口
+	publicRoute.POST("/logGroup/upload", func(c echo.Context) error {
 		file, err := c.FormFile("log")
 		if err != nil {
 			return err
@@ -246,6 +347,7 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		if err != nil {
 			return fmt.Errorf("read upload file error: %w", err)
 		}
+
 		ts := getTags(c.QueryParams())
 
 		groupId := c.QueryParam("groupId")
@@ -271,7 +373,7 @@ func NewEcho(socket *socket.WebSocket, core *CoreApi, config *config.Config, pro
 		return c.JSON(200, common.NewSuccessResponse(createFile))
 	})
 
-	route.POST("/log/upload", func(c echo.Context) error {
+	publicRoute.POST("/log/upload", func(c echo.Context) error {
 		file, err := c.FormFile("log")
 		if err != nil {
 			return err


### PR DESCRIPTION
# Page-Spy 登录认证功能实现文档

## 功能概述

为了提高安全性，我们为 Page-Spy 添加了登录认证功能，使得房间列表和日志列表页面需要输入密码才能访问。此功能包括前端和后端两部分实现，确保敏感数据和操作得到有效保护。

## 认证方式

- 采用简单的密码认证方式
- 密码存储和验证完全由后端管理
- 系统不使用默认密码，用户需要在首次使用时设置密码
- 认证成功后，后端返回令牌，前端存储此令牌以保持登录状态
- 登录认证保护房间列表和日志列表页面，以及敏感API

## JWT认证实现

我们对认证机制进行了升级，采用业界标准的JWT（JSON Web Token）方式进行认证：

### JWT特性

- 首次启动服务时，随机生成JWT密钥，用于签名和验证
- JWT密钥可通过环境变量`JWT_SECRET`配置，如果未配置则自动生成
- Token具有可配置的过期时间，通过环境变量`JWT_EXPIRATION_HOURS`设置（默认24小时）
- Token过期后，用户需要重新登录
- 登录密码优先级：环境变量`AUTH_PASSWORD` > 配置文件密码

### 后端JWT实现

- 在`page-spy-api/serve/middleware/jwt.go`中实现了JWT相关功能
- 提供了生成Token、验证Token的方法
- 支持可配置的Token过期时间
- 认证中间件自动验证Token的有效性和是否过期

### 前端JWT处理

- 前端存储Token和过期时间
- 自动检测Token是否过期，过期则要求重新登录
- 提供刷新Token的功能接口
- API请求自动添加Token到请求头

## 前端实现

### 1. 认证上下文管理

在 `page-spy-web/src/utils/AuthContext.tsx` 中实现了 AuthContext，用于全局管理认证状态，提供了以下功能：

- `isAuthenticated`: 表示当前用户是否已认证
- `needPasswordSetup`: 表示系统是否需要设置密码
- `login(password)`: 将密码发送到后端验证接口进行验证
- `setPassword(password)`: 设置系统密码
- `logout()`: 登出并清除认证信息
- `checkPasswordStatus()`: 检查系统密码状态
- `getAuthToken()`: 获取存储的认证令牌
- `expiresAt`: 令牌过期时间戳
- `refreshToken()`: 刷新认证令牌

```typescript
const login = async (password: string): Promise<boolean> => {
  try {
    // 调用后端验证接口
    const response = await request.post<any>('/auth/verify', {
      data: { password },
    });

    if (response.success && response.data?.success) {
      // 设置令牌和过期时间
      setTokenAndExpiration(
        response.data.token, 
        response.data.expiresIn || 86400 // 默认24小时
      );
      
      // 显示登录成功提示
      message.success(i18n.t('auth.login_success'));
      
      return true;
    }
    
    // 登录失败提示
    message.error(i18n.t('auth.incorrect_password'));
    return false;
  } catch (error) {
    // 检查是否需要设置密码
    if (error.response?.data?.needPasswordSetup) {
      setNeedPasswordSetup(true);
      message.warning(i18n.t('auth.need_set_password'));
      return false;
    }
    
    return false;
  }
};
```

### 2. 登录界面

在 `page-spy-web/src/components/AuthLogin/index.tsx` 中实现了登录界面，包括：

- 密码输入框
- 登录按钮
- 错误提示
- 支持多语言（英文、中文、日文）
- 当检测到系统需要设置密码时，自动切换到密码设置界面

```tsx
// 如果需要设置密码，显示密码设置组件
if (needPasswordSetup) {
  return <PasswordSetup />;
}
```

### 3. 密码设置界面

在 `page-spy-web/src/components/PasswordSetup/index.tsx` 中实现了密码设置界面，包括：

- 新密码输入框
- 确认密码输入框
- 密码复杂度验证
- 密码匹配验证
- 设置按钮
- 多语言支持

### 4. 路由保护

在 `page-spy-web/src/components/ProtectedRoute/index.tsx` 中实现了路由保护组件，用于：

- 拦截未认证用户对受保护路由的访问
- 自动重定向到登录界面
- 登录成功后重定向回原路由

### 5. 路由配置

在 `page-spy-web/src/routes/config.tsx` 中配置了受保护的路由：

```tsx
{
  path: 'room-list',
  element: (
    <ProtectedRoute>
      <RoomList />
    </ProtectedRoute>
  ),
},
{
  path: 'log-list',
  element: (
    <ProtectedRoute>
      <LogList />
    </ProtectedRoute>
  ),
},
```

### 6. API请求认证

在 `page-spy-web/src/apis/request.ts` 中添加了认证头支持：

```typescript
if (requireAuth) {
  const token = getAuthToken();
  if (token) {
    headers['Authorization'] = `Bearer ${token}`;
  }
}
```

### 7. 令牌过期处理

在API请求中添加了令牌过期处理：

```typescript
if (error instanceof RequestFailed) {
  // 检查是否是因为令牌过期导致的未授权
  if (error.statusCode === 401) {
    // 令牌过期返回的特定错误代码
    const errorData = error.data as any;
    if (errorData && errorData.code === "EXPIRED_OR_INVALID_TOKEN") {
      console.log('令牌已过期，需要重新登录');
      
      // 清除无效的令牌
      localStorage.removeItem('page-spy-auth-token');
      localStorage.removeItem('page-spy-token-expires-at');
      
      // 刷新页面使应用进入未登录状态
      window.location.reload();
    }
  }
}
```

### 8. 导航栏登出

在 `page-spy-web/src/pages/Layouts/NavMenu/index.tsx` 中添加了登出按钮，让用户可以方便地退出登录。

### 9. 国际化支持

添加了英文、中文和日文的认证相关翻译，支持多语言环境下的使用。

## 后端实现

### 1. JWT工具函数

在 `page-spy-api/serve/middleware/jwt.go` 中实现了JWT相关功能：

```go
// GenerateToken 生成JWT令牌
func GenerateToken(expirationHours int) (string, error) {
  // 如果密钥未初始化，先初始化
  if len(jwtSecret) == 0 {
    InitJWTSecret()
  }

  // 确定过期时间
  expirationTime := time.Now().Add(time.Hour * time.Duration(expirationHours))
  if expirationHours <= 0 {
    // 默认24小时
    expirationTime = time.Now().Add(time.Hour * 24)
  }

  // 创建声明
  claims := &Claims{
    RegisteredClaims: jwt.RegisteredClaims{
      ExpiresAt: jwt.NewNumericDate(expirationTime),
      IssuedAt:  jwt.NewNumericDate(time.Now()),
      NotBefore: jwt.NewNumericDate(time.Now()),
      Issuer:    "page-spy",
    },
  }

  // 创建令牌
  token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

  // 签名字符串
  tokenString, err := token.SignedString(jwtSecret)
  if err != nil {
    return "", err
  }

  return tokenString, nil
}
```

### 2. 配置文件

在 `page-spy-api/config/config.go` 中添加了 AuthPassword 字段，用于配置认证密码：

```go
type Config struct {
  // ... 其他字段
  AuthPassword string `json:"authPassword"`
  // ... 其他字段
}
```

在 `page-spy-api/config.json` 中，可以不设置 `authPassword` 字段或设置为空字符串，系统会在首次访问时要求用户设置密码。

### 3. 密码验证接口

在 `page-spy-api/serve/route/route.go` 中添加了密码验证接口：

```go
// 添加验证密码接口
route.POST("/auth/verify", func(c echo.Context) error {
  // ... 请求参数处理 ...
  
  // 获取配置中的密码
  authPassword := config.AuthPassword
  
  // 检查环境变量中是否设置了密码
  envPassword := os.Getenv("AUTH_PASSWORD")
  if envPassword != "" {
    // 如果环境变量中设置了密码，优先使用环境变量中的密码
    authPassword = envPassword
  }
  
  // 如果未配置密码，返回需要设置密码的信息
  if authPassword == "" {
    return c.JSON(http.StatusUnauthorized, common.NewSuccessResponse(map[string]interface{}{
      "success":           false,
      "message":           "系统未设置密码，请先设置密码",
      "code":              "PASSWORD_REQUIRED",
      "needPasswordSetup": true,
    }))
  }
  
  // ... 密码验证逻辑 ...
  
  // 密码正确，生成JWT令牌
  token := generateAuthToken()
  
  // 获取过期时间用于前端显示
  expirationHours := selfMiddleware.GetJWTExpirationHours()
  
  return c.JSON(http.StatusOK, common.NewSuccessResponse(map[string]interface{}{
    "success":   true,
    "message":   "认证成功",
    "token":     token,
    "expiresIn": expirationHours * 3600, // 过期时间，单位秒
  }))
})
```

### 4. 密码设置接口

在 `page-spy-api/serve/route/route.go` 中添加了密码设置接口，支持环境变量配置：

```go
// 添加设置密码的接口
route.POST("/auth/set-password", func(c echo.Context) error {
  // ... 请求参数处理 ...

  // 检查环境变量中是否设置了密码
  envPassword := os.Getenv("AUTH_PASSWORD")
  if envPassword != "" {
    // 如果环境变量中设置了密码，提示用户
    return c.JSON(http.StatusBadRequest, common.NewSuccessResponse(map[string]interface{}{
      "success": false,
      "message": "系统使用环境变量中的密码，无法通过接口设置",
      "code":    "ENV_PASSWORD_SET",
    }))
  }

  // 密码验证逻辑
  if passwordReq.Password == "" {
    return c.JSON(http.StatusBadRequest, common.NewSuccessResponse(map[string]interface{}{
      "success": false,
      "message": "密码不能为空",
      "code":    "INVALID_PASSWORD",
    }))
  }

  // ... 保存配置文件 ...

  // 生成JWT令牌
  token := generateAuthToken()
  
  // 获取过期时间用于前端显示
  expirationHours := selfMiddleware.GetJWTExpirationHours()

  return c.JSON(http.StatusOK, common.NewSuccessResponse(map[string]interface{}{
    "success":            true,
    "message":            "密码设置成功",
    "token":              token,
    "passwordConfigured": true,
    "expiresIn":          expirationHours * 3600, // 过期时间，单位秒
  }))
})
```

### 5. 认证中间件

在 `page-spy-api/serve/middleware/auth.go` 中实现了JWT认证中间件，用于：

- 验证请求的 Authorization 头
- 检查令牌的有效性和是否过期
- 拦截未认证的请求
- 如果未配置密码，返回需要设置密码的提示

```go
// Auth 中间件用于验证请求的认证信息
func Auth(config *config.Config) echo.MiddlewareFunc {
  // ... 密码配置检查 ...

  // 初始化JWT密钥
  InitJWTSecret()

  return func(next echo.HandlerFunc) echo.HandlerFunc {
    return func(c echo.Context) error {
      // ... 获取和验证Authorization头 ...

      // 解析和验证JWT令牌
      claims, err := ParseToken(token)
      if err != nil {
        // 令牌无效或已过期
        return c.JSON(http.StatusUnauthorized, common.NewSuccessResponse(map[string]interface{}{
          "message": "认证令牌已过期或无效",
          "code":    "EXPIRED_OR_INVALID_TOKEN",
        }))
      }

      // 将JWT声明存储在上下文中，如需要
      c.Set("jwtClaims", claims)

      return next(c)
    }
  }
}
```

### 6. 启动时初始化

在 `page-spy-api/serve/run.go` 中，在服务启动时初始化JWT密钥：

```go
func Run() {
  // 在服务启动时初始化JWT密钥
  middleware.InitJWTSecret()
  
  // ... 其他启动逻辑 ...
}
```

### 7. 路由保护

在 `page-spy-api/serve/route/route.go` 中，将敏感 API 添加到受保护的路由组：

```go
// 创建受保护的路由组
protectedRoute := route.Group("")
protectedRoute.Use(selfMiddleware.Auth(config))

// 需要认证的接口添加到protectedRoute
protectedRoute.GET("/room/list", func(c echo.Context) error {
  socket.ListRooms(c.Response(), c.Request())
  return nil
})

protectedRoute.GET("/log/list", func(c echo.Context) error {
  // ... 处理逻辑
})

protectedRoute.DELETE("/log/delete", func(c echo.Context) error {
  // ... 处理逻辑
})
```

## 认证流程

1. 用户访问受保护页面（room-list 或 log-list）
2. 前端路由保护检测到用户未认证，重定向到登录页面
3. 前端检查系统是否设置了密码：
   - 如果未设置密码，显示密码设置界面
   - 如果已设置密码，显示登录界面
4. 密码设置流程：
   - 用户在密码设置界面输入新密码并确认
   - 前端调用 `/api/v1/auth/set-password` 接口设置密码
   - 后端将密码写入配置文件并返回JWT令牌
   - 前端保存令牌和过期时间，完成设置
5. 登录流程：
   - 用户输入密码并提交
   - 前端将密码发送到后端接口 `/api/v1/auth/verify` 进行验证
   - 验证成功则返回令牌和过期时间；失败则返回错误信息
6. 认证成功后，当用户访问需要验证的API时，前端自动在请求头中添加Bearer令牌
7. 后端中间件验证JWT令牌的有效性和是否过期
8. 令牌过期后，前端自动检测并要求用户重新登录
9. 用户可以通过导航栏中的登出按钮退出登录状态

## 使用方法

1. 启动应用后，访问 Room List 或 Log List 页面
2. 系统会自动跳转到登录页面
3. 如果系统未设置密码，会显示密码设置界面：
   - 输入新密码和确认密码
   - 点击"设置密码"按钮
   - 设置成功后自动登录
4. 如果系统已设置密码，会显示登录界面：
   - 输入密码并登录
5. 登录成功后即可访问受保护的页面
6. 点击导航栏中的"退出登录"按钮可以退出登录状态

## 自定义配置

以下环境变量可用于自定义认证行为：

- `AUTH_PASSWORD`：设置认证密码，优先级高于配置文件
- `JWT_SECRET`：设置JWT签名密钥，如不设置则自动生成
- `JWT_EXPIRATION_HOURS`：设置JWT令牌过期时间（小时），默认为24小时

也可以通过修改后端配置文件来自定义认证密码：

```json
// page-spy-api/config.json
{
  "port": "6752",
  "authPassword": "your-custom-password"
}
```


## 多语言支持

认证功能支持英文、中文和日文界面，会根据用户浏览器或系统设置自动选择合适的语言。可以通过导航栏中的语言切换按钮手动切换界面语言。

## 安全性考虑

1. 密码仅在后端存储和验证，提高了安全性
2. 前端不存储实际密码，只存储认证成功后的令牌
3. API请求需要有效的认证令牌，防止未授权访问
4. 采用JWT令牌认证机制，符合行业标准做法
5. JWT令牌具有过期时间，增强了安全性
6. 系统要求用户设置密码，避免使用默认密码带来的安全风险
7. JWT密钥首次启动时随机生成，增加了安全性
8. 支持通过环境变量设置敏感信息，避免硬编码和配置文件中的明文存储 