### PR TITLE
Fix api cors config.

### DIFF
--- a/serve/middleware/cors.go
+++ b/serve/middleware/cors.go
@@ -34,15 +34,15 @@ func CORS(c *config.Config) echo.MiddlewareFunc {
 		}
 
 		if !isEmptyArray(c.CorsConfig.AllowMethods) {
-			config.AllowOrigins = c.CorsConfig.AllowMethods
+			config.AllowMethods = c.CorsConfig.AllowMethods
 		}
 
 		if !isEmptyArray(c.CorsConfig.AllowHeaders) {
-			config.AllowOrigins = c.CorsConfig.AllowHeaders
+			config.AllowHeaders = c.CorsConfig.AllowHeaders
 		}
 
 		if !isEmptyArray(c.CorsConfig.ExposeHeaders) {
-			config.AllowOrigins = c.CorsConfig.ExposeHeaders
+			config.ExposeHeaders = c.CorsConfig.ExposeHeaders
 		}
 	}
 


### PR DESCRIPTION
There is a minor coding error where `AllowOrigins` is being overwritten by the values of AllowMethods, AllowHeaders, and ExposeHeaders.